### PR TITLE
remove duplicate macro

### DIFF
--- a/GpuBuffer.h
+++ b/GpuBuffer.h
@@ -3,6 +3,10 @@
 #include <cuda_runtime.h>
 #include <cstdio>
 #include "endian_utils.h" // why: ensure little-endian assumptions
+#include "cuda_helpers.h" // why: macro CUDA_CHECK_ERROR
+#ifndef CUDA_CHECK_ERROR
+#error "CUDA_CHECK_ERROR must be defined via cuda_helpers.h"
+#endif
 
 // RAII wrapper around cudaMalloc/cudaFree
 class GpuBuffer {

--- a/endian_utils.h
+++ b/endian_utils.h
@@ -8,10 +8,3 @@ constexpr bool is_little_endian() {
 
 static_assert(is_little_endian(), "Big-endian architectures are not supported");
 
-#define CUDA_CHECK_ERROR(call) do { \
-    cudaError_t _e = (call); \
-    if(_e != cudaSuccess) { \
-        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(_e)); \
-    } \
-} while(0)
-

--- a/tests/check_gpu_buffer_macro.cpp
+++ b/tests/check_gpu_buffer_macro.cpp
@@ -1,0 +1,7 @@
+#include "GpuBuffer.h"
+#include <cuda_runtime.h>
+int main() {
+    // ensures macro expands without redef
+    CUDA_CHECK_ERROR(cudaSuccess);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- drop CUDA_CHECK_ERROR macro from endian_utils.h
- include cuda_helpers.h in GpuBuffer.h and assert presence of macro
- add test to check CUDA_CHECK_ERROR in GpuBuffer

## Testing
- `make` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68426c40b1588326bd94955205adc46d