### PR TITLE
Fix compile errors

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -243,7 +243,12 @@ bool TFastBase::LoadFromFile(char* fn)
 			for (int k = 0; k < 256; k++)
 			{
 				TListRec* list = &lists[i][j][k];
-				fread(&list->cnt, 1, 2, fp);
+                                size_t read_sz = fread(&list->cnt, 1, 2, fp);
+                                if (read_sz != 2)
+                                {
+                                        fclose(fp);
+                                        return false;
+                                }
 				if (list->cnt)
 				{
 					u32 grow = list->cnt / 2;


### PR DESCRIPTION
## Summary
- fix `TFastBase::LoadFromFile` to check `fread` result
- initialize CUDA error variable and update kernel calls
- remove duplicate variable declarations and pass stream parameters

## Testing
- `make` *(fails: cuda_runtime.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842dd02ee788326a57ee60327c99caf